### PR TITLE
Standardize constants and update documentation for new tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Below is a list of tools included in this repository.
 | **[Root Locker](hardening/Root%20Locker/root-locker.bash)** | Locks the root account to prevent direct logins. | Hardening | Root privileges | Preserves sudo access |
 | **[SSHD Hardening](hardening/SSHD%20Hardening/harden-sshd.bash)** | Harden OpenSSH server (sshd) per Lynis recommendations. | Hardening | Root privileges | Creates backups |
 | **[UFW Cloudflare](hardening/UFW%20Cloudflare/ufw-cloudflare.bash)** | Configure UFW to only allow HTTP/HTTPS from Cloudflare IP ranges. | Hardening | Root privileges, UFW, Internet connection | Creates backups |
+| **[Nginx WAF](hardening/Nginx%20WAF/nginx-waf.bash)** | Install and configure ModSecurity with OWASP Core Rule Set for Nginx. | Hardening | Root privileges, Nginx, Internet connection | **IMPORTANT:** Currently in **Beta** |
 
 > [!NOTE]
 > All scripts include version information in their headers. Check individual CHANGELOG.md files in each tool's directory for version history and updates.

--- a/auditing/Lynis Installer/lynis-installer.bash
+++ b/auditing/Lynis Installer/lynis-installer.bash
@@ -11,24 +11,25 @@
 #
 ########################################################################################
 
-C_YELLOW="$(printf '\033[1;33m')"
-C_GREEN="$(printf '\033[0;32m')"
-C_BLUE="$(printf '\033[0;34m')"
-C_CYAN="$(printf '\033[0;36m')"
-C_RED="$(printf '\033[1;31m')"
-C_NC="$(printf '\033[0m')"
 
-C_SUCCESS="${C_GREEN}==>${C_NC} "
-C_ERROR="${C_RED}ERROR:${C_NC} "
-C_WARNING="${C_YELLOW}==>${C_NC} "
-C_INFO="${C_BLUE}==>${C_NC} "
-C_NOTE="${C_CYAN}==>${C_NC} "
+readonly C_YELLOW=$'\033[1;33m'
+readonly C_GREEN=$'\033[0;32m'
+readonly C_BLUE=$'\033[0;34m'
+readonly C_CYAN=$'\033[0;36m'
+readonly C_RED=$'\033[1;31m'
+readonly C_NC=$'\033[0m'
+
+readonly C_ERROR="${C_RED}ERROR:${C_NC} "
+readonly C_SUCC="${C_GREEN}==>${C_NC} "
+readonly C_WARN="${C_YELLOW}==>${C_NC} "
+readonly C_INFO="${C_BLUE}==>${C_NC} "
+readonly C_NOTE="${C_CYAN}==>${C_NC} "
 
 
 read -rp "${C_NOTE}We will now download lynis. Press [Enter] to continue."
 
 if [[ -d "$HOME/lynis" ]]; then
-    echo "${C_WARNING}Lynis is already downloaded to your system" >&2
+    echo "${C_WARN}Lynis is already downloaded to your system" >&2
     echo "${C_NOTE}  Current location: '$HOME/lynis'"
     echo -e "\n${C_INFO}Exiting..."
     exit 0
@@ -47,6 +48,6 @@ git clone https://github.com/CISOfy/lynis || {
     exit 1
 }
 
-echo -e "\n${C_SUCCESS}Lynis has been downloaded to your system"
+echo -e "\n${C_SUCC}Lynis has been downloaded to your system"
 echo "${C_NOTE}To perform a system scan with lynis, execute the following command" \
     "in the lynis root directory: sudo ./lynis audit system"

--- a/hardening/Nginx WAF/CHANGELOG.md
+++ b/hardening/Nginx WAF/CHANGELOG.md
@@ -3,3 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial changelog tracking for the Nginx WAF hardening tool.
+
+## [1.0.0-beta] - 2024-01-01
+
+### Added
+- Initial beta release of the Nginx WAF hardening tool.
+- Baseline documentation and configuration for deploying and maintaining the WAF setup.
+- Initial hardening-focused rules and project structure for protecting Nginx-based deployments.

--- a/hardening/Nginx WAF/CHANGELOG.md
+++ b/hardening/Nginx WAF/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## v1.0.0 - ....
+
+- Full production-ready release

--- a/hardening/Nginx WAF/CHANGELOG.md
+++ b/hardening/Nginx WAF/CHANGELOG.md
@@ -7,11 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [Unreleased]
 
 ### Added
+
 - Initial changelog tracking for the Nginx WAF hardening tool.
 
-## [1.0.0-beta] - 2024-01-01
+## [1.0.0-beta] - 2026-05-17
 
 ### Added
+
 - Initial beta release of the Nginx WAF hardening tool.
 - Baseline documentation and configuration for deploying and maintaining the WAF setup.
 - Initial hardening-focused rules and project structure for protecting Nginx-based deployments.

--- a/hardening/Nginx WAF/CHANGELOG.md
+++ b/hardening/Nginx WAF/CHANGELOG.md
@@ -3,7 +3,3 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## v1.0.0 - ....
-
-- Full production-ready release

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -1,0 +1,225 @@
+#!/bin/bash
+#
+# This script automates the installation and configuration of ModSecurity as a Web
+# Application Firewall (WAF) for Nginx on Linux systems. It clones the ModSecurity and
+# ModSecurity-nginx repositories, builds and installs the ModSecurity module, configures
+# Nginx to load the module, and sets up the OWASP Core Rule Set for basic protection against
+# common web vulnerabilities.
+#
+# Version: v1.0.0-beta
+# License: MIT License
+#          Copyright (c) 2026 Hunter T. (StrangeRanger)
+#
+############################################################################################
+set -Eeuo pipefail
+####[ Global Variables ]####################################################################
+
+
+readonly C_GREEN=$'\033[0;32m'
+readonly C_BLUE=$'\033[0;34m'
+readonly C_CYAN=$'\033[0;36m'
+readonly C_RED=$'\033[1;31m'
+readonly C_NC=$'\033[0m'
+
+readonly C_ERROR="${C_RED}ERROR:${C_NC} "
+readonly C_SUCC="${C_GREEN}==>${C_NC} "
+readonly C_INFO="${C_BLUE}==>${C_NC} "
+readonly C_NOTE="${C_CYAN}==>${C_NC} "
+
+readonly C_SO_FILE="ngx_http_modsecurity_module.so"
+readonly C_MODULES_AVAILABLE="/etc/nginx/modules-available"
+readonly C_MODULES_ENABLED="/etc/nginx/modules-enabled"
+readonly C_MODSEC_PATH="/etc/nginx/modsec"
+readonly C_MODSEC_CONF_PATH="$C_MODSEC_PATH/modsecurity.conf"
+readonly C_MAIN_CONF_PATH="$C_MODSEC_PATH/main.conf"
+
+# TODO: ERROR CATCHING ELSE WILL JUST FAIL SILENTLY IF NGINX IS NOT INSTALLED OR NOT IN PATH
+C_NGINX_VERSION="$(nginx -V 2>&1 | sed -n 's/^nginx version: nginx\/\([0-9.]\+\).*/\1/p')"
+C_NGINX_CONFIG_ARGS="$(nginx -V 2>&1 | awk -F': ' '/configure arguments/ {print $2}')"
+C_MODULES_PATH="$(sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p' <<<"$C_NGINX_CONFIG_ARGS" | head -n 1)"
+readonly C_NGINX_VERSION C_NGINX_CONFIG_ARGS C_MODULES_PATH
+
+modsecurity_clone_exists=false
+coreruleset_clone_exists=false
+
+
+####[Functions]#############################################################################
+
+
+error_exit() {
+    local message="${1:-An unknown error occurred}"
+    local exit_code="${2:-1}"
+
+    echo "${C_ERROR}${message}" >&2
+    exit "$exit_code"
+}
+
+on_err() {
+    local exit_code=$?
+    error_exit "Command failed at line ${BASH_LINENO[0]}: ${BASH_COMMAND}" "$exit_code"
+}
+
+require_non_empty() {
+    local var_name="$1"
+    local var_value="${2:-}"
+
+    [[ -n "$var_value" ]] || error_exit "Required value '${var_name}' is empty"
+}
+
+
+####[ Trapping & Initial Checks ]###########################################################
+
+
+trap on_err ERR
+
+require_non_empty "C_NGINX_VERSION" "$C_NGINX_VERSION"
+require_non_empty "C_NGINX_CONFIG_ARGS" "$C_NGINX_CONFIG_ARGS"
+require_non_empty "C_MODULES_PATH" "$C_MODULES_PATH"
+
+
+####[ Main ]################################################################################
+
+
+echo "${C_INFO}Starting ModSecurity installation and configuration process..."
+
+###
+### [ Clone and build ModSecurity ]
+###
+
+if [[ ! -d "ModSecurity/.git" ]]; then
+    echo "${C_INFO}Cloning ModSecurity repository..."
+    git clone --depth 1 -b v3/master --single-branch https://github.com/owasp-modsecurity/ModSecurity
+else
+    echo "${C_NOTE}ModSecurity repository already exists"
+    modsecurity_clone_exists=true
+fi
+
+pushd ModSecurity >/dev/null
+if [[ $modsecurity_clone_exists == true ]]; then
+    echo "${C_INFO}Updating existing ModSecurity repository..."
+    # TODO: Consider adding a check to ensure the local repository is on the correct branch
+    # and there are no local changes before pulling.
+    git pull
+fi
+
+echo "${C_INFO}Initializing and updating git submodules..."
+git submodule update --init --recursive
+
+echo "${C_INFO}Building ModSecurity..."
+./build.sh
+
+echo "${C_INFO}Configuring ModSecurity..."
+./configure --with-pcre2
+
+echo "${C_INFO}Compiling ModSecurity..."
+# Runs the build in parallel using all available CPU cores except one.
+make -j"$(nproc --ignore=1)"
+
+echo "${C_INFO}Installing ModSecurity..."
+make install
+popd >/dev/null
+
+###
+### [ Clone, build, and install ModSecurity Nginx module ]
+###
+
+if [[ ! -d "ModSecurity-nginx/.git" ]]; then
+    echo "${C_INFO}Cloning ModSecurity-nginx repository..."
+    git clone --depth 1 https://github.com/owasp-modsecurity/ModSecurity-nginx
+else
+    echo "${C_NOTE}ModSecurity-nginx repository already exists"
+    echo "${C_INFO}Updating existing ModSecurity-nginx repository..."
+    pushd ModSecurity-nginx >/dev/null
+    git pull
+    popd >/dev/null
+fi
+
+echo "${C_INFO}Downloading Nginx source code for version '${C_NGINX_VERSION}'..."
+[[ -f "nginx-${C_NGINX_VERSION}.tar.gz" ]] && rm -f "nginx-${C_NGINX_VERSION}.tar.gz"
+wget "https://nginx.org/download/nginx-${C_NGINX_VERSION}.tar.gz"
+
+echo "${C_INFO}Extracting Nginx source code..."
+tar -xzf "nginx-${C_NGINX_VERSION}.tar.gz"
+
+pushd "nginx-${C_NGINX_VERSION}" >/dev/null
+echo "${C_INFO}Configuring Nginx with ModSecurity module..."
+# Split the Nginx configure arguments into an array to handle cases where there are multiple
+# arguments with spaces.
+mapfile -t nginx_cfg_argv < <(xargs -n1 <<<"$C_NGINX_CONFIG_ARGS")
+./configure "${nginx_cfg_argv[@]}" --with-compat --add-dynamic-module=../ModSecurity-nginx
+
+echo "${C_INFO}Compiling ModSecurity Nginx module..."
+make modules
+
+echo "${C_INFO}Installing ModSecurity Nginx module..."
+mkdir -p "$C_MODULES_PATH"
+sudo cp objs/"$C_SO_FILE" "$C_MODULES_PATH"
+sudo chmod 0644 "$C_MODULES_PATH/$C_SO_FILE"
+popd >/dev/null
+
+echo "${C_INFO}Setting up Nginx configuration for ModSecurity module..."
+sudo mkdir -p "$C_MODULES_AVAILABLE" "$C_MODULES_ENABLED"
+echo "load_module $C_MODULES_PATH/$C_SO_FILE;" \
+    | sudo tee "$C_MODULES_AVAILABLE/50-modsecurity.conf" >/dev/null
+
+if [[ -e $C_MODULES_ENABLED/50-modsecurity.conf ]]; then
+    echo "${C_NOTE}ModSecurity module is already enabled"
+else
+    echo "${C_INFO}Enabling ModSecurity module in Nginx..."
+    sudo ln -s "$C_MODULES_AVAILABLE/50-modsecurity.conf" "$C_MODULES_ENABLED/50-modsecurity.conf"
+fi
+
+###
+### [ Configure ModSecurity and OWASP Core Rule Set ]
+###
+
+echo "${C_INFO}Configuring ModSecurity rules..."
+pushd ModSecurity >/dev/null
+sudo mkdir -p "$C_MODSEC_PATH"
+sudo cp unicode.mapping "$C_MODSEC_PATH/"
+sudo cp modsecurity.conf-recommended "$C_MODSEC_CONF_PATH"
+
+echo "${C_INFO}Enabling ModSecurity in On mode..."
+sudo sed -i 's/SecRuleEngine DetectionOnly/SecRuleEngine On/' "$C_MODSEC_CONF_PATH"
+popd >/dev/null
+
+pushd "$C_MODSEC_PATH" >/dev/null
+if [[ ! -d coreruleset/.git ]]; then
+    echo "${C_INFO}Cloning OWASP Core Rule Set repository..."
+    sudo git clone https://github.com/coreruleset/coreruleset.git
+else
+    echo "${C_NOTE}OWASP Core Rule Set repository already exists"
+    coreruleset_clone_exists=true
+fi
+
+# Use cd intentionally; keep dir stack unchanged so popd jumps to original pushd location.
+cd coreruleset
+
+if [[ $coreruleset_clone_exists == true ]]; then
+    echo "${C_INFO}Updating existing OWASP Core Rule Set repository..."
+    # TODO: Consider adding a check to ensure the local repository is on the correct branch
+    # and there are no local changes before pulling.
+    sudo git pull
+fi
+
+echo "${C_INFO}Configuring OWASP Core Rule Set..."
+sudo cp crs-setup.conf.example crs-setup.conf
+popd >/dev/null
+
+echo "${C_INFO}Writing ModSecurity main configuration..."
+sudo tee "$C_MAIN_CONF_PATH" >/dev/null <<EOF
+Include $C_MODSEC_CONF_PATH
+Include $C_MODSEC_PATH/coreruleset/crs-setup.conf
+Include $C_MODSEC_PATH/coreruleset/rules/*.conf
+EOF
+
+###
+### [ Finalize and restart Nginx ]
+###
+
+echo "${C_INFO}Testing Nginx configuration..."
+sudo nginx -t
+echo "${C_INFO}Restarting Nginx to apply changes..."
+sudo systemctl restart nginx
+
+echo "${C_SUCC}DONE"

--- a/hardening/Root Locker/root-locker.bash
+++ b/hardening/Root Locker/root-locker.bash
@@ -12,16 +12,17 @@
 #
 ########################################################################################
 
-C_GREEN="$(printf '\033[0;32m')"
-C_BLUE="$(printf '\033[0;34m')"
-C_CYAN="$(printf '\033[0;36m')"
-C_RED="$(printf '\033[1;31m')"
-C_NC="$(printf '\033[0m')"
 
-C_SUCCESS="${C_GREEN}==>${C_NC} "
-C_ERROR="${C_RED}ERROR:${C_NC} "
-C_INFO="${C_BLUE}==>${C_NC} "
-C_NOTE="${C_CYAN}==>${C_NC} "
+readonly C_GREEN=$'\033[0;32m'
+readonly C_BLUE=$'\033[0;34m'
+readonly C_CYAN=$'\033[0;36m'
+readonly C_RED=$'\033[1;31m'
+readonly C_NC=$'\033[0m'
+
+readonly C_ERROR="${C_RED}ERROR:${C_NC} "
+readonly C_SUCC="${C_GREEN}==>${C_NC} "
+readonly C_INFO="${C_BLUE}==>${C_NC} "
+readonly C_NOTE="${C_CYAN}==>${C_NC} "
 
 
 if (( EUID != 0 )); then
@@ -38,4 +39,4 @@ usermod -L root || {
     exit 1
 }
 
-echo -e "\n${C_SUCCESS}The root account has been locked"
+echo -e "\n${C_SUCC}The root account has been locked"

--- a/hardening/SSHD Hardening/harden-sshd.bash
+++ b/hardening/SSHD Hardening/harden-sshd.bash
@@ -22,17 +22,16 @@ readonly C_SESSION_BACKUP="$C_TMP_DIR/sshd_config.session_backup"
 readonly C_CONFIG_FILE_BAK="/etc/ssh/sshd_config.bak"
 readonly C_CONFIG_FILE="/etc/ssh/sshd_config"
 
-C_YELLOW="$(printf '\033[1;33m')"
-C_GREEN="$(printf '\033[0;32m')"
-C_BLUE="$(printf '\033[0;34m')"
-C_CYAN="$(printf '\033[0;36m')"
-C_RED="$(printf '\033[1;31m')"
-C_NC="$(printf '\033[0m')"
-readonly C_YELLOW C_GREEN C_BLUE C_CYAN C_RED C_NC
+readonly C_YELLOW=$'\033[1;33m'
+readonly C_GREEN=$'\033[0;32m'
+readonly C_BLUE=$'\033[0;34m'
+readonly C_CYAN=$'\033[0;36m'
+readonly C_RED=$'\033[1;31m'
+readonly C_NC=$'\033[0m'
 
-readonly C_WARNING="${C_YELLOW}==>${C_NC} "
-readonly C_SUCCESS="${C_GREEN}==>${C_NC} "
 readonly C_ERROR="${C_RED}ERROR:${C_NC} "
+readonly C_WARN="${C_YELLOW}==>${C_NC} "
+readonly C_SUCC="${C_GREEN}==>${C_NC} "
 readonly C_INFO="${C_BLUE}==>${C_NC} "
 readonly C_NOTE="${C_CYAN}==>${C_NC} "
 
@@ -96,18 +95,18 @@ clean_exit() {
 
     case "$exit_code" in
         0|1) echo "" ;;
-        129) echo -e "\n\n${C_WARNING}Hangup signal detected (SIGHUP)" ;;
-        130) echo -e "\n\n${C_WARNING}User interrupt detected (SIGINT)" ;;
-        143) echo -e "\n\n${C_WARNING}Termination signal detected (SIGTERM)" ;;
-        *)   echo -e "\n\n${C_WARNING}Exiting with code: $exit_code" ;;
+        129) echo -e "\n\n${C_WARN}Hangup signal detected (SIGHUP)" ;;
+        130) echo -e "\n\n${C_WARN}User interrupt detected (SIGINT)" ;;
+        143) echo -e "\n\n${C_WARN}Termination signal detected (SIGTERM)" ;;
+        *)   echo -e "\n\n${C_WARN}Exiting with code: $exit_code" ;;
     esac
 
     # Check if we need to restore the original configurations.
     if [[ $modifications_in_progress == true ]] && [[ -f "$C_SESSION_BACKUP" ]]; then
-        echo "${C_WARNING}Script was interrupted during configuration changes"
+        echo "${C_WARN}Script was interrupted during configuration changes"
         echo "${C_INFO}Restoring original 'sshd_config'..."
         if cp "$C_SESSION_BACKUP" "$C_CONFIG_FILE"; then
-            echo "${C_SUCCESS}Successfully restored original configurations"
+            echo "${C_SUCC}Successfully restored original configurations"
             echo "${C_INFO}Cleaning up..."
             [[ -d "$C_TMP_DIR" ]] && rm -rf "$C_TMP_DIR"
         else
@@ -145,7 +144,7 @@ fi
 
 ## Confirm that 'sshd_config' exists.
 if [[ ! -f $C_CONFIG_FILE ]]; then
-    echo "${C_WARNING}'sshd_config' doesn't exist" >&2
+    echo "${C_WARN}'sshd_config' doesn't exist" >&2
     echo "${C_NOTE}openssh-server may not be installed"
     exit 1
 fi
@@ -220,7 +219,7 @@ for key in "${!C_SSHD_CONFIG[@]}"; do
             || echo "${C_ERROR}Failed to set '${key} ${C_SSHD_CONFIG[$key]}'" >&2
     ## If the configuration is not present in the file.
     else
-        echo "${C_WARNING}'${key}' not found in configuration file" >&2
+        echo "${C_WARN}'${key}' not found in configuration file" >&2
     fi
 done
 
@@ -232,16 +231,16 @@ modifications_in_progress=false
 
 echo -e "\n${C_INFO}Restarting SSH service..."
 if systemctl restart sshd 2>/dev/null; then
-    echo "${C_SUCCESS}SSH service (sshd) restarted successfully"
+    echo "${C_SUCC}SSH service (sshd) restarted successfully"
 elif systemctl restart ssh 2>/dev/null; then
-    echo "${C_SUCCESS}SSH service (ssh) restarted successfully"
+    echo "${C_SUCC}SSH service (ssh) restarted successfully"
 else
     echo "${C_ERROR}Failed to restart SSH service (tried both 'sshd' and 'ssh')" >&2
     echo "${C_NOTE}You may need to restart the SSH service manually"
 fi
 
 echo ""
-echo "${C_SUCCESS}Finished hardening sshd"
+echo "${C_SUCC}Finished hardening sshd"
 echo "${C_NOTE}It is highly recommended to manually:"
 echo "${C_NOTE}  1) Change the default sshd port (22)"
 echo "${C_NOTE}  2) Disable PasswordAuthentication in favor of PubkeyAuthentication"

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -19,17 +19,16 @@ readonly C_SLEEP_TIME=1
 readonly C_CLOUDFLARE_IPV4_RANGES_URL="https://www.cloudflare.com/ips-v4/"
 readonly C_CLOUDFLARE_IPV6_RANGES_URL="https://www.cloudflare.com/ips-v6/"
 
-C_YELLOW="$(printf '\033[1;33m')"
-C_GREEN="$(printf '\033[0;32m')"
-C_BLUE="$(printf '\033[0;34m')"
-C_CYAN="$(printf '\033[0;36m')"
-C_RED="$(printf '\033[1;31m')"
-C_NC="$(printf '\033[0m')"
-readonly C_YELLOW C_GREEN C_BLUE C_CYAN C_RED C_NC
+readonly C_YELLOW=$'\033[1;33m'
+readonly C_GREEN=$'\033[0;32m'
+readonly C_BLUE=$'\033[0;34m'
+readonly C_CYAN=$'\033[0;36m'
+readonly C_RED=$'\033[1;31m'
+readonly C_NC=$'\033[0m'
 
-readonly C_SUCCESS="${C_GREEN}==>${C_NC} "
-readonly C_WARNING="${C_YELLOW}==>${C_NC} "
 readonly C_ERROR="${C_RED}ERROR:${C_NC} "
+readonly C_SUCC="${C_GREEN}==>${C_NC} "
+readonly C_WARN="${C_YELLOW}==>${C_NC} "
 readonly C_INFO="${C_BLUE}==>${C_NC} "
 readonly C_NOTE="${C_CYAN}==>${C_NC} "
 
@@ -53,15 +52,15 @@ clean_exit() {
 
     case "$exit_code" in
         0|1) echo "" ;;
-        129) echo -e "\n\n${C_WARNING}Hangup signal detected (SIGHUP)" ;;
-        130) echo -e "\n\n${C_WARNING}User interrupt detected (SIGINT)" ;;
-        143) echo -e "\n\n${C_WARNING}Termination signal detected (SIGTERM)" ;;
-        *)   echo -e "\n\n${C_WARNING}Exiting with code: $exit_code" ;;
+        129) echo -e "\n\n${C_WARN}Hangup signal detected (SIGHUP)" ;;
+        130) echo -e "\n\n${C_WARN}User interrupt detected (SIGINT)" ;;
+        143) echo -e "\n\n${C_WARN}Termination signal detected (SIGTERM)" ;;
+        *)   echo -e "\n\n${C_WARN}Exiting with code: $exit_code" ;;
     esac
 
     case $stage in
         2|3|4)
-            echo "${C_WARNING}Interrupt occurred during stage '$stage'; incomplete changes"
+            echo "${C_WARN}Interrupt occurred during stage '$stage'; incomplete changes"
             echo "${C_INFO}Temporarily disabling UFW..."
             ufw disable
             echo "${C_INFO}Restoring previous UFW rules..."
@@ -207,5 +206,5 @@ fi
 
 sleep "$C_SLEEP_TIME"
 echo "${C_NOTE}Waiting '$C_SLEEP_TIME' second for changes to take effect..."
-echo "${C_SUCCESS}Finished setting up UFW with Cloudflare IP ranges"
+echo "${C_SUCC}Finished setting up UFW with Cloudflare IP ranges"
 clean_exit 0


### PR DESCRIPTION
This pull request introduces a new Nginx Web Application Firewall (WAF) tool and standardizes color and status variable naming across multiple Bash scripts for consistency and clarity. Additionally, it updates documentation to reflect the new tool and adds a changelog for the Nginx WAF script.

**Major changes include:**

### New Tool Addition

* Added `nginx-waf.bash`, a comprehensive script to automate the installation and configuration of ModSecurity with the OWASP Core Rule Set for Nginx, including error handling, colored output, and modular configuration.
* Added a corresponding `CHANGELOG.md` for the new Nginx WAF tool, adhering to Keep a Changelog and Semantic Versioning standards.
* Updated the `README.md` to include the new Nginx WAF tool in the list of available scripts, noting its beta status.

### Code Consistency and Refactoring

* Standardized color variable definitions and status message variables (e.g., `C_SUCC`, `C_WARN`) across `lynis-installer.bash`, `root-locker.bash`, `harden-sshd.bash`, and `ufw-cloudflare.bash` for improved readability and maintainability. [[1]](diffhunk://#diff-c55ab6ecf225abc504279145307a1a078f4f1b14b675a34e5c0ce7c12689b9dbL14-R32) [[2]](diffhunk://#diff-72e615ce76955bd4786907096424562853b57670f3730e0d2b554517b2079745L15-R25) [[3]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L25-R34) [[4]](diffhunk://#diff-260b8daffd45755aa9129d260ee13f589a8c60fc44de3929a7bc4488ca26707dL22-R31)
* Updated all scripts to use the new standardized status variables in their output messages, replacing previous inconsistent usages. [[1]](diffhunk://#diff-c55ab6ecf225abc504279145307a1a078f4f1b14b675a34e5c0ce7c12689b9dbL50-R51) [[2]](diffhunk://#diff-72e615ce76955bd4786907096424562853b57670f3730e0d2b554517b2079745L41-R42) [[3]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L99-R109) [[4]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L148-R147) [[5]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L223-R222) [[6]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L235-R243) [[7]](diffhunk://#diff-260b8daffd45755aa9129d260ee13f589a8c60fc44de3929a7bc4488ca26707dL56-R63) [[8]](diffhunk://#diff-260b8daffd45755aa9129d260ee13f589a8c60fc44de3929a7bc4488ca26707dL210-R209)