### PR TITLE
Fix clean_exit bypass and update version number

### DIFF
--- a/hardening/UFW Cloudflare/CHANGELOG.md
+++ b/hardening/UFW Cloudflare/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.4 - 2026-05-21
+
+### Fixed
+
+- Replaced the use of `exit 1` with `clean_exit 1` to ensure temp files are removed on exits.
+
 ## v1.0.3 - 2026-05-21
 
 ### Added

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -2,7 +2,7 @@
 #
 # Set up UFW to only allow HTTP and HTTPS traffic from Cloudflare's IP ranges.
 #
-# Version: v1.0.3
+# Version: v1.0.4
 # License: MIT License
 #          Copyright (c) 2024-2026 Hunter T. (StrangeRanger)
 #

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -88,7 +88,7 @@ clean_exit() {
 # shellcheck disable=SC2329,SC2317
 #   These appear to be false positives. The function is intended to be used in the 'ERR'
 #   trap handler, and the exit code is passed implicitly via the special variable '$?'.
-on_err() {
+on_error() {
     local exit_code=$?
 
     echo "${C_ERROR}Command failed at line ${BASH_LINENO[0]}: ${BASH_COMMAND}" >&2
@@ -102,7 +102,7 @@ on_err() {
 trap 'clean_exit 129' SIGHUP
 trap 'clean_exit 130' SIGINT
 trap 'clean_exit 143' SIGTERM
-trap 'on_err' ERR
+trap 'on_error' ERR
 
 
 ####[ Prepping ]############################################################################

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -110,7 +110,7 @@ trap 'on_error' ERR
 
 if (( EUID != 0 )); then
     echo "${C_ERROR}This script requires root privilege" >&2
-    exit 1
+    clean_exit 1
 fi
 
 


### PR DESCRIPTION
This pull request updates the `ufw-cloudflare.bash` script to improve its error handling and resource cleanup. The main change is to ensure that temporary files are properly removed when the script exits due to errors or insufficient privileges by replacing direct calls to `exit 1` with the `clean_exit 1` function. Additionally, the error trap handler function has been renamed for clarity.

Error handling and cleanup improvements:

* Replaced all instances of `exit 1` with `clean_exit 1` to ensure temporary files are removed on exit, improving script reliability and cleanup. (`hardening/UFW Cloudflare/ufw-cloudflare.bash`, `hardening/UFW Cloudflare/CHANGELOG.md`) [[1]](diffhunk://#diff-260b8daffd45755aa9129d260ee13f589a8c60fc44de3929a7bc4488ca26707dL105-R113) [[2]](diffhunk://#diff-9eb7fc50371b3e662c016dbc27ab37a4067b1aabe63ed2f303212d639c7312a9R7-R12)
* Renamed the error trap handler function from `on_err` to `on_error` for better clarity and consistency, and updated the corresponding trap. (`hardening/UFW Cloudflare/ufw-cloudflare.bash`)

Other:

* Updated the script version from `v1.0.3` to `v1.0.4`. (`hardening/UFW Cloudflare/ufw-cloudflare.bash`)