### PR TITLE
Refactor error handling and update documentation for Nginx WAF

### DIFF
--- a/hardening/Nginx WAF/CHANGELOG.md
+++ b/hardening/Nginx WAF/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.0-beta.4 - 2026-05-24
+
+### Changed
+
+- Refactored error handling and required-value validation to report failures to stderr and preserve the original exit code.
+- Simplified ModSecurity repository setup by removing the separate clone-state flag.
+- Marked detected Nginx version, configure arguments, and modules path as readonly after validation.
+- Raised the Bash requirement to 4.3 or newer.
+
 ## v1.0.0-beta.3 - 2026-05-20
 
 ### Added

--- a/hardening/Nginx WAF/README.md
+++ b/hardening/Nginx WAF/README.md
@@ -7,7 +7,7 @@ Installs and configures ModSecurity with the OWASP Core Rule Set for Nginx.
 
 ## Requirements
 
-- Bash 4.0 or newer
+- Bash 4.3 or newer
 - Root privileges
 - Nginx 1.24.0 or newer, installed and available in `PATH`
 - A Debian/Ubuntu-style system with `apt-get` and `dpkg`

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -111,7 +111,7 @@ trap on_error ERR
 if command -v nginx &>/dev/null; then
     C_NGINX_VERSION="$(nginx -V 2>&1 | sed -n 's/^nginx version: nginx\/\([0-9.]\+\).*/\1/p')"
     C_NGINX_CONFIG_ARGS="$(nginx -V 2>&1 | awk -F': ' '/configure arguments/ {print $2}')"
-    C_MODULES_PATH="$(sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p' <<<"$C_NGINX_CONFIG_ARGS" | head -n 1)"
+    C_MODULES_PATH="$(sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p' <<< "$C_NGINX_CONFIG_ARGS" | head -n 1)"
     is_not_empty C_NGINX_VERSION || exit 1
     is_not_empty C_NGINX_CONFIG_ARGS || exit 1
     is_not_empty C_MODULES_PATH || exit 1

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -77,7 +77,7 @@ on_error() {
 }
 
 ####
-# Check if a variable is empty. If it is empty, print an error message and exit with
+# Check if a variable is empty. If it is empty, print an error message and return with
 # code 1.
 is_not_empty() {
     local var_name="$1"

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -10,6 +10,11 @@
 # License: MIT License
 #          Copyright (c) 2026 Hunter T. (StrangeRanger)
 #
+# TODO: Delete existing nginx source directory if it exists? Maybe a cleanup?
+# TODO: Go through and verify 'sudo' is only used where necessary.
+# TODO: Go through and ensure proper ownership and permissions of create, copied, and
+#   modified files.
+#
 ############################################################################################
 set -Eeuo pipefail
 ####[ Global Variables ]####################################################################
@@ -52,7 +57,6 @@ C_NGINX_VERSION=""
 C_NGINX_CONFIG_ARGS=""
 C_MODULES_PATH=""
 
-modsecurity_clone_exists=false
 coreruleset_clone_exists=false
 required_pkgs=("${C_REQUIRED_PKGS[@]}")
 missing_pkgs=()
@@ -196,8 +200,6 @@ else
     git pull
     popd >/dev/null
 fi
-
-# TODO: Delete existing nginx source directory if it exists? Maybe a cleanup?
 
 echo "${C_INFO}Downloading Nginx source code for version '${C_NGINX_VERSION}'..."
 [[ -f "nginx-${C_NGINX_VERSION}.tar.gz" ]] && rm -f "nginx-${C_NGINX_VERSION}.tar.gz"

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -61,24 +61,38 @@ missing_pkgs=()
 ####[Functions]#############################################################################
 
 
-on_err() {
+####
+# Print an error message and exit with the provided exit code.
+#
+# NOTE: This function is intended to be used in the 'on_error' trap handler.
+on_error() {
     local exit_code=$?
-    echo "${C_ERROR}Command failed at line ${BASH_LINENO[0]}: ${BASH_COMMAND}"
-    echo "${C_ERROR}Exit code: $exit_code"
+
+    echo "${C_ERROR}Command failed at line ${BASH_LINENO[0]}: ${BASH_COMMAND}" >&2
+    exit "$exit_code"
 }
 
-require_non_empty() {
+####
+# Check if a variable is empty. If it is empty, print an error message and exit with
+# code 1.
+is_not_empty() {
     local var_name="$1"
-    local var_value="${2:-}"
+    local -n var_ref="$1"
 
-    [[ -n "$var_value" ]] || error_exit "Required value '${var_name}' is empty"
+    if [[ -z "$var_ref" ]]; then
+        echo "${C_ERROR}Required value '${var_name}' is empty" >&2
+        return 1
+    fi
 }
 
+####
+# Add additional packages to the list of required packages if certain Nginx modules are
+# enabled.
 require_pkg() {
     local required_pkg="$1"
 
     for pkg in "${required_pkgs[@]}"; do
-        [[ $pkg == "$required_pkg" ]] && return 0
+        [[ $pkg == "$required_pkg" ]] && return
     done
 
     required_pkgs+=("$required_pkg")
@@ -88,7 +102,7 @@ require_pkg() {
 ####[ Trapping & Initial Checks ]###########################################################
 
 
-trap on_err ERR
+trap on_error ERR
 
 
 ####[ Initial Checks ]######################################################################
@@ -98,11 +112,12 @@ if command -v nginx &>/dev/null; then
     C_NGINX_VERSION="$(nginx -V 2>&1 | sed -n 's/^nginx version: nginx\/\([0-9.]\+\).*/\1/p')"
     C_NGINX_CONFIG_ARGS="$(nginx -V 2>&1 | awk -F': ' '/configure arguments/ {print $2}')"
     C_MODULES_PATH="$(sed -n 's/.*--modules-path=\([^ ]*\).*/\1/p' <<<"$C_NGINX_CONFIG_ARGS" | head -n 1)"
-    require_non_empty "C_NGINX_VERSION" "$C_NGINX_VERSION"
-    require_non_empty "C_NGINX_CONFIG_ARGS" "$C_NGINX_CONFIG_ARGS"
-    require_non_empty "C_MODULES_PATH" "$C_MODULES_PATH"
+    is_not_empty C_NGINX_VERSION || exit 1
+    is_not_empty C_NGINX_CONFIG_ARGS || exit 1
+    is_not_empty C_MODULES_PATH || exit 1
 else
-    error_exit "Nginx is not installed or not in PATH"
+    echo "${C_ERROR}Nginx is not installed or not in PATH" >&2
+    exit 1
 fi
 
 [[ $C_NGINX_CONFIG_ARGS == *--with-http_image_filter_module* ]] && require_pkg "libgd-dev"

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -115,6 +115,7 @@ if command -v nginx &>/dev/null; then
     is_not_empty C_NGINX_VERSION || exit 1
     is_not_empty C_NGINX_CONFIG_ARGS || exit 1
     is_not_empty C_MODULES_PATH || exit 1
+    readonly C_NGINX_VERSION C_NGINX_CONFIG_ARGS C_MODULES_PATH
 else
     echo "${C_ERROR}Nginx is not installed or not in PATH" >&2
     exit 1
@@ -154,13 +155,10 @@ fi
 if [[ ! -d "ModSecurity/.git" ]]; then
     echo "${C_INFO}Cloning ModSecurity repository..."
     git clone --depth 1 -b v3/master --single-branch https://github.com/owasp-modsecurity/ModSecurity
+    pushd ModSecurity >/dev/null
 else
     echo "${C_NOTE}ModSecurity repository already exists"
-    modsecurity_clone_exists=true
-fi
-
-pushd ModSecurity >/dev/null
-if [[ $modsecurity_clone_exists == true ]]; then
+    pushd ModSecurity >/dev/null
     echo "${C_INFO}Updating existing ModSecurity repository..."
     # TODO: Consider adding a check to ensure the local repository is on the correct branch
     # and there are no local changes before pulling.
@@ -198,6 +196,8 @@ else
     git pull
     popd >/dev/null
 fi
+
+# TODO: Delete existing nginx source directory if it exists? Maybe a cleanup?
 
 echo "${C_INFO}Downloading Nginx source code for version '${C_NGINX_VERSION}'..."
 [[ -f "nginx-${C_NGINX_VERSION}.tar.gz" ]] && rm -f "nginx-${C_NGINX_VERSION}.tar.gz"

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -66,7 +66,7 @@ missing_pkgs=()
 
 
 ####
-# Print an error message and exit with the provided exit code.
+# Print an error message and exit with the triggering command’s status.
 #
 # NOTE: This function is intended to be used in the 'on_error' trap handler.
 on_error() {

--- a/hardening/Nginx WAF/nginx-waf.bash
+++ b/hardening/Nginx WAF/nginx-waf.bash
@@ -6,7 +6,7 @@
 # Nginx to load the module, and sets up the OWASP Core Rule Set for basic protection against
 # common web vulnerabilities.
 #
-# Version: v1.0.0-beta.3
+# Version: v1.0.0-beta.4
 # License: MIT License
 #          Copyright (c) 2026 Hunter T. (StrangeRanger)
 #

--- a/hardening/SSHD Hardening/CHANGELOG.md
+++ b/hardening/SSHD Hardening/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.2.2 - 2026-05-24
+
+### Fixed
+
+- Removed duplicate cleanup code.
+
 ## v2.2.1 - 2026-05-21
 
 ### Fixed

--- a/hardening/SSHD Hardening/CHANGELOG.md
+++ b/hardening/SSHD Hardening/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Replaced the use of `exit 1` with `clean_exit 1` to ensure temp files are removed on exits.
+- Preserve recovery files when restoring `sshd_config` fails, and only remove the temp directory after successful cleanup.
 
 ## v2.2.0 - 2025-11-02
 

--- a/hardening/SSHD Hardening/CHANGELOG.md
+++ b/hardening/SSHD Hardening/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.2.1 - 2026-05-21
+
+### Fixed
+
+- Replaced the use of `exit 1` with `clean_exit 1` to ensure temp files are removed on exits.
+
 ## v2.2.0 - 2025-11-02
 
 ### Added

--- a/hardening/SSHD Hardening/harden-sshd.bash
+++ b/hardening/SSHD Hardening/harden-sshd.bash
@@ -105,8 +105,6 @@ clean_exit() {
         echo "${C_INFO}Restoring original 'sshd_config'..."
         if cp "$C_SESSION_BACKUP" "$C_CONFIG_FILE"; then
             echo "${C_SUCC}Successfully restored original configurations"
-            echo "${C_INFO}Cleaning up..."
-            [[ -d "$C_TMP_DIR" ]] && rm -rf "$C_TMP_DIR"
         else
             clean_up=false
             echo "${C_ERROR}Failed to restore 'sshd_config'" >&2

--- a/hardening/SSHD Hardening/harden-sshd.bash
+++ b/hardening/SSHD Hardening/harden-sshd.bash
@@ -89,6 +89,7 @@ modifications_in_progress=false
 # code.
 clean_exit() {
     local exit_code="$1"
+    local clean_up=true
 
     case "$exit_code" in
         0|1) echo "" ;;
@@ -107,12 +108,15 @@ clean_exit() {
             echo "${C_INFO}Cleaning up..."
             [[ -d "$C_TMP_DIR" ]] && rm -rf "$C_TMP_DIR"
         else
+            clean_up=false
             echo "${C_ERROR}Failed to restore 'sshd_config'" >&2
             echo "${C_NOTE}Session backup is available at: $C_SESSION_BACKUP"
             echo "${C_NOTE}Permanent backup is available at: $C_CONFIG_FILE_BAK"
             echo "${C_NOTE}Temp directory preserved for manual recovery: $C_TMP_DIR"
         fi
-    else
+    fi
+
+    if [[ $clean_up == true ]]; then
         echo "${C_INFO}Cleaning up..."
         [[ -d "$C_TMP_DIR" ]] && rm -rf "$C_TMP_DIR"
     fi

--- a/hardening/SSHD Hardening/harden-sshd.bash
+++ b/hardening/SSHD Hardening/harden-sshd.bash
@@ -85,11 +85,8 @@ modifications_in_progress=false
 
 
 ####
-# Cleanly exit the script by removing temporary files, restoring backups if needed, and
-# displaying a message based on the exit code.
-#
-# PARAMETERS:
-#   - $1: exit_code (Required)
+# Remove temporary files, restore backups if needed, and display a message based on the exit
+# code.
 clean_exit() {
     local exit_code="$1"
 
@@ -139,14 +136,14 @@ trap 'clean_exit 143' SIGTERM
 ## Check if the script was executed with root privilege.
 if (( EUID != 0 )); then
     echo "${C_ERROR}This script requires root privilege" >&2
-    exit 1
+    clean_exit 1
 fi
 
 ## Confirm that 'sshd_config' exists.
 if [[ ! -f $C_CONFIG_FILE ]]; then
     echo "${C_WARN}'sshd_config' doesn't exist" >&2
     echo "${C_NOTE}openssh-server may not be installed"
-    exit 1
+    clean_exit 1
 fi
 
 
@@ -167,9 +164,9 @@ if [[ -f $C_CONFIG_FILE_BAK ]]; then
     case "$choice" in
         y*)
             echo "${C_INFO}Overwriting backup of 'sshd_config'..."
-            cp $C_CONFIG_FILE $C_CONFIG_FILE_BAK || {
+            cp "$C_CONFIG_FILE" "$C_CONFIG_FILE_BAK" || {
                 echo "${C_ERROR}Failed to overwrite backup of 'sshd_config'" >&2
-                exit 1
+                clean_exit 1
             }
             ;;
         *)
@@ -182,8 +179,7 @@ else
     echo "${C_INFO}Backing up 'sshd_config'..."
     cp "$C_CONFIG_FILE" "$C_CONFIG_FILE_BAK" || {
         echo "${C_ERROR}Failed to back up sshd_config" >&2
-        echo "${C_NOTE}Create a backup of the original 'sshd_config' file before continuing"
-        exit 1
+        clean_exit 1
     }
 fi
 

--- a/hardening/SSHD Hardening/harden-sshd.bash
+++ b/hardening/SSHD Hardening/harden-sshd.bash
@@ -9,7 +9,7 @@
 #       - Session backup (.session_backup): For automatic script restoration during
 #         interruptions.
 #
-# Version: v2.2.0
+# Version: v2.2.1
 # License: MIT License
 #          Copyright (c) 2020-2026 Hunter T. (StrangeRanger)
 #

--- a/hardening/SSHD Hardening/harden-sshd.bash
+++ b/hardening/SSHD Hardening/harden-sshd.bash
@@ -207,8 +207,8 @@ for key in "${!C_SSHD_CONFIG[@]}"; do
 
     regex_key="${key}Regex"
     sed_regex="0,/${C_SSHD_CONFIG[$regex_key]}/s/${C_SSHD_CONFIG[$regex_key]}/${key} ${C_SSHD_CONFIG[$key]}/"
-    echo "${C_INFO}Checking '${key}'..."
 
+    echo "${C_INFO}Checking '${key}'..."
     ## Check if the key is already set to the desired value.
     if grep -Eq "^${key} ${C_SSHD_CONFIG[$key]}$" "$C_CONFIG_FILE"; then
         echo "${C_NOTE}${key} already set to '${C_SSHD_CONFIG[$key]}'"

--- a/hardening/UFW Cloudflare/CHANGELOG.md
+++ b/hardening/UFW Cloudflare/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Replaced the use of `exit 1` with `clean_exit 1` to ensure temp files are removed on exits.
+- Print the inactive UFW error message to stderr.
 
 ## v1.0.3 - 2026-05-21
 

--- a/hardening/UFW Cloudflare/CHANGELOG.md
+++ b/hardening/UFW Cloudflare/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.5
+
+### Fixed
+
+- Print the inactive UFW error message to stderr.
+
 ## v1.0.4 - 2026-05-21
 
 ### Fixed
 
 - Replaced the use of `exit 1` with `clean_exit 1` to ensure temp files are removed on exits.
-- Print the inactive UFW error message to stderr.
 
 ## v1.0.3 - 2026-05-21
 

--- a/hardening/UFW Cloudflare/CHANGELOG.md
+++ b/hardening/UFW Cloudflare/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.5
+## v1.0.5 - 2026-05-24
 
 ### Fixed
 

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -89,8 +89,7 @@ clean_exit() {
 # Print the error message, the line number, and the command that caused the error.
 #
 # shellcheck disable=SC2329,SC2317
-#   These appear to be false positives. The function is intended to be used in the 'ERR'
-#   trap handler, and the exit code is passed implicitly via the special variable '$?'.
+#   on_error is invoked indirectly by the ERR trap.
 on_error() {
     local exit_code=$?
 

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -85,6 +85,9 @@ clean_exit() {
     exit "$exit_code"
 }
 
+####
+# Print the error message, the line number, and the command that caused the error.
+#
 # shellcheck disable=SC2329,SC2317
 #   These appear to be false positives. The function is intended to be used in the 'ERR'
 #   trap handler, and the exit code is passed implicitly via the special variable '$?'.

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -121,7 +121,7 @@ read -rp "${C_NOTE}We will now configure Cloudflare UFW rules. Press [Enter] to 
 
 echo "${C_INFO}Checking UFW status..."
 if ! ufw status | grep -q '^Status: active$'; then
-    echo "${C_ERROR}UFW is not active"
+    echo "${C_ERROR}UFW is not active" >&2
     clean_exit 1
 fi
 

--- a/hardening/UFW Cloudflare/ufw-cloudflare.bash
+++ b/hardening/UFW Cloudflare/ufw-cloudflare.bash
@@ -2,7 +2,7 @@
 #
 # Set up UFW to only allow HTTP and HTTPS traffic from Cloudflare's IP ranges.
 #
-# Version: v1.0.4
+# Version: v1.0.5
 # License: MIT License
 #          Copyright (c) 2024-2026 Hunter T. (StrangeRanger)
 #


### PR DESCRIPTION
This pull request includes updates and bug fixes for three hardening scripts: Nginx WAF, SSHD Hardening, and UFW Cloudflare. The most significant changes focus on improving error handling, validation, and cleanup procedures, as well as updating requirements and documentation for clarity.

---

**Nginx WAF Improvements:**

* Refactored error handling to report failures to stderr and preserve the original exit code, and updated required-value validation logic for robustness (`nginx-waf.bash`, `CHANGELOG.md`) [[1]](diffhunk://#diff-3de7be83b2b19f7541368c868626bbab694de805bd73c4a02a4455b3e313eca3L64-R99) [[2]](diffhunk://#diff-2ff7101b0422231194237eea6f5135f21d2f5080fe9a5a1305b292c0155b2fb4R7-R15).
* Simplified ModSecurity repository setup by removing the separate clone-state flag and streamlining repository update logic (`nginx-waf.bash`) [[1]](diffhunk://#diff-3de7be83b2b19f7541368c868626bbab694de805bd73c4a02a4455b3e313eca3L55) [[2]](diffhunk://#diff-3de7be83b2b19f7541368c868626bbab694de805bd73c4a02a4455b3e313eca3R162-L148).
* Marked detected Nginx version, configure arguments, and modules path as readonly after validation for improved immutability (`nginx-waf.bash`).
* Raised the Bash requirement to 4.3 or newer and updated documentation accordingly (`nginx-waf.bash`, `README.md`, `CHANGELOG.md`) [[1]](diffhunk://#diff-a19b7ad7743a703c6655ee066da2f445ce149a92a5f0fe987ae30b22695d28baL10-R10) [[2]](diffhunk://#diff-2ff7101b0422231194237eea6f5135f21d2f5080fe9a5a1305b292c0155b2fb4R7-R15).
* Updated version to `v1.0.0-beta.4` (`nginx-waf.bash`, `CHANGELOG.md`) [[1]](diffhunk://#diff-3de7be83b2b19f7541368c868626bbab694de805bd73c4a02a4455b3e313eca3L9-R17) [[2]](diffhunk://#diff-2ff7101b0422231194237eea6f5135f21d2f5080fe9a5a1305b292c0155b2fb4R7-R15).

**SSHD Hardening Bug Fixes:**

* Replaced direct `exit 1` calls with `clean_exit 1` to ensure temporary files are always cleaned up, and improved recovery file handling on failure (`harden-sshd.bash`, `CHANGELOG.md`) [[1]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L142-R150) [[2]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L170-R173) [[3]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L185-R186) [[4]](diffhunk://#diff-b39ce459e6fa12986c714e23e07a8bbe088313d687d31aeb138cc543ee5be146R7-R13).
* Only remove the temp directory after successful cleanup, preserving recovery files if restoration fails (`harden-sshd.bash`).
* Updated version to `v2.2.1` (`harden-sshd.bash`, `CHANGELOG.md`) [[1]](diffhunk://#diff-1723332c3cd06bbe7ab9a97e6a5d086a067762c21d265e56a3dda730fcf3d583L12-R12) [[2]](diffhunk://#diff-b39ce459e6fa12986c714e23e07a8bbe088313d687d31aeb138cc543ee5be146R7-R13).

**UFW Cloudflare Bug Fix:**

* Ensured the inactive UFW error message is printed to stderr for better error visibility (`ufw-cloudflare.bash`, `CHANGELOG.md`) [[1]](diffhunk://#diff-260b8daffd45755aa9129d260ee13f589a8c60fc44de3929a7bc4488ca26707dL124-R126) [[2]](diffhunk://#diff-9eb7fc50371b3e662c016dbc27ab37a4067b1aabe63ed2f303212d639c7312a9R7-R12).
* Updated version to `v1.0.5` (`ufw-cloudflare.bash`, `CHANGELOG.md`) [[1]](diffhunk://#diff-260b8daffd45755aa9129d260ee13f589a8c60fc44de3929a7bc4488ca26707dL5-R5) [[2]](diffhunk://#diff-9eb7fc50371b3e662c016dbc27ab37a4067b1aabe63ed2f303212d639c7312a9R7-R12).